### PR TITLE
IAT-3268: TIMS UI - the history tab does not display the 'Began creat…

### DIFF
--- a/src/main/java/org/opentestsystem/ap/item/history/ItemHistoryApi.java
+++ b/src/main/java/org/opentestsystem/ap/item/history/ItemHistoryApi.java
@@ -168,25 +168,25 @@ public class ItemHistoryApi {
 
 
     /**
-     * Looks up the first item record in the ITEM table.  It is considered the 'began creation' record as that is
-     * the commit message we use when it is generated.  The finished creating report is needed to get the
-     * user's full name.  If there is no finished creating report then the
+     * Looks up the first item record in the ITEM table.  It is considered the 'began creation' record as that is the
+     * commit message we use when it is generated.  The oldest record is needed to get the user's full name.  If there
+     * is no oldest record then full name is null on the returned instance.
      *
-     * @param itemId The item to look up the first record for
-     * @param finishedCreatingRecord The record that is the finshed creating record.
+     * @param itemId              The item to look up the first record for
+     * @param oldestHistoryRecord The record oldest history record for the item.
      * @return The history record representing the first entry of the item in the system.
      */
-    private ItemHistoryEntity getBeganCreationRecord(String itemId, ItemHistoryEntity finishedCreatingRecord) {
+    private ItemHistoryEntity getBeganCreationRecord(String itemId, ItemHistoryEntity oldestHistoryRecord) {
         // get the very first record for the item
         ItemEntity itemEntity = this.itemEntityRepository.findFirstMaster(itemId);
 
         // we need the full name so we use the one on the finished creating record
         // if there is no finished creating record we default to just the user's email (i.e. the createdBy)
-        String createdByFullName = Objects.nonNull(finishedCreatingRecord)
-            ? finishedCreatingRecord.getCommitByFullname()
+        String createdByFullName = Objects.nonNull(oldestHistoryRecord)
+            ? oldestHistoryRecord.getCommitByFullname()
             : itemEntity.getCreatedBy();
 
-        ItemHistoryEntity  beganCreationRecord = new ItemHistoryEntity();
+        ItemHistoryEntity beganCreationRecord = new ItemHistoryEntity();
         beganCreationRecord.setCreatedDate(itemEntity.getCreatedDate());
         beganCreationRecord.setItemId(itemId);
         beganCreationRecord.setCommitMessage(BEGAN_CREATION_COMMIT_MESSAGE);

--- a/src/main/java/org/opentestsystem/ap/item/history/ItemHistoryApi.java
+++ b/src/main/java/org/opentestsystem/ap/item/history/ItemHistoryApi.java
@@ -183,7 +183,6 @@ public class ItemHistoryApi {
         // we need the full name so we use the one on the finished creating record
         // if there is no finished creating record we default to just the user's email (i.e. the createdBy)
         String createdByFullName = Objects.nonNull(finishedCreatingRecord)
-                && StringUtils.isNotBlank(finishedCreatingRecord.getCommitByFullname())
             ? finishedCreatingRecord.getCommitByFullname()
             : itemEntity.getCreatedBy();
 

--- a/src/main/java/org/opentestsystem/ap/item/history/ItemHistoryApi.java
+++ b/src/main/java/org/opentestsystem/ap/item/history/ItemHistoryApi.java
@@ -93,21 +93,25 @@ public class ItemHistoryApi {
      */
     @GetMapping("{itemId}")
     public ItemHistoryResponse getItemHistory(@PathVariable String itemId) {
-        ItemHistoryEntity finishedCreatingItem = null;
+        ItemHistoryEntity oldestHistoryRecord = null;
 
         List<ItemHistoryEntity> results = this.itemHistoryRepository.findByItemId(itemId);
 
         if (CollectionUtils.isNotEmpty(results)) {
             // the last record in the list is the finished creating record
-            finishedCreatingItem = results.get(results.size() - 1);
+            oldestHistoryRecord = results.get(results.size() - 1);
         } else {
             // if the list is empty, it might be null so create a new list for only the first entry
             results = new ArrayList<>(1);
         }
 
-        // put this at the end of the list
-        ItemHistoryEntity beganCreationRecord = this.getBeganCreationRecord(itemId, finishedCreatingItem);
-        results.add(beganCreationRecord);
+        // some history records might have a 'Began creation' record, if so then no need to create one
+        if (!BEGAN_CREATION_COMMIT_MESSAGE.equalsIgnoreCase(oldestHistoryRecord.getCommitMessage())) {
+            // create a "Began creation" record
+            ItemHistoryEntity beganCreationRecord = this.getBeganCreationRecord(itemId, oldestHistoryRecord);
+            // put it last, meaning its the oldest
+            results.add(beganCreationRecord);
+        }
 
         return new ItemHistoryResponse(results.stream().map(this::toHistoryModel).collect(Collectors.toList()));
     }
@@ -179,6 +183,7 @@ public class ItemHistoryApi {
         // we need the full name so we use the one on the finished creating record
         // if there is no finished creating record we default to just the user's email (i.e. the createdBy)
         String createdByFullName = Objects.nonNull(finishedCreatingRecord)
+                && StringUtils.isNotBlank(finishedCreatingRecord.getCommitByFullname())
             ? finishedCreatingRecord.getCommitByFullname()
             : itemEntity.getCreatedBy();
 


### PR DESCRIPTION
…ion' entry.

The issue was there were two 'Began creation.' records showing up in an item's history tab.  I was creating one always, assuming the item history table does not have a 'Began creation' record.   However, there is an item in QA that has a 'Began creation' record in the history table.  It is item 209078.  I'm not sure how that got there.  The normal flow of creating a new item does not have a 'Began creation' history record.  The History Service ignores CREATE and DELETE events, and it only handles COMMIT and PATCH.

Regardless of why there is a 'Began creation' history record, I think it makes sense to first check if the history table has that and if so then we will not generate one.  And that is what the change is below.